### PR TITLE
Fix ESLint autocmd typo

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -139,12 +139,12 @@ return {
 				},
 			},
 			setup = {
-				eslint = function()
-					vim.cmd([[ autocmd BufWritePre *.tsx,*.ts,*.jsx,*,js EslintFixAll ]])
-				end,
-			},
-		},
-	},
+                                eslint = function()
+                                        vim.cmd([[ autocmd BufWritePre *.tsx,*.ts,*.jsx,*.js EslintFixAll ]])
+                                end,
+                        },
+                },
+        },
 	{
 		"neovim/nvim-lspconfig",
 		opts = function()


### PR DESCRIPTION
## Summary
- fix typo in ESLint autocmd patterns so js files are formatted on save

## Testing
- `grep -n "BufWritePre" -n lua/plugins/lsp.lua`

------
https://chatgpt.com/codex/tasks/task_e_6866b1b5ecb88331bc0d8de83db0fc4b